### PR TITLE
Some adjustments to fragment paging tests

### DIFF
--- a/src/dev/TestServer/server/routes/paging.js
+++ b/src/dev/TestServer/server/routes/paging.js
@@ -38,6 +38,7 @@ var paging = function(coverage) {
   coverage['PagingSingleFailure'] = 0;
   coverage['PagingMultipleFailure'] = 0;
   coverage['PagingMultipleFailureUri'] = 0;
+  coverage['PagingFragment'] = 0;
 
   router.get('/single', function(req, res, next) {
     coverage["PagingSingle"]++;
@@ -121,24 +122,24 @@ var paging = function(coverage) {
   });
 
   router.get('/multiple/fragment/:tenant', function(req, res, next) {
-    if(req.query.api_version != "1.6" || req.tenant != "test_user") {
+    if(req.query.api_version != "1.6" || req.params.tenant != "test_user") {
       res.status(400).end("Required path and query parameters are not present");
     }
     else {
-      res.status(200).end('{ "values": [ {"properties":{"id" : ' + req.params.pagenumber + ', "name": "product"}} ], "odata.nextLink": "next?page="' + ++req.query.page + '"}');
+      res.status(200).end('{ "values": [ {"properties":{"id" : 1, "name": "product"}} ], "odata.nextLink": "next?page=2"}');
     }
   });
 
   router.get('/multiple/fragment/:tenant/next', function(req, res, next) {
-    if(req.query.api_version != "1.6" || req.tenant != "test_user") {
+    if(req.query.api_version != "1.6" || req.params.tenant != "test_user") {
       res.status(400).end("Required path and query parameters are not present");
     }
     else if(req.query.page < 10) {
-      res.status(200).end('{ "values": [ {"properties":{"id" : ' + req.params.pagenumber + ', "name": "product"}} ], "odata.nextLink": "next?page="' + ++req.query.page + '"}');
+      res.status(200).end('{ "values": [ {"properties":{"id" : ' + req.query.page + ', "name": "product"}} ], "odata.nextLink": "next?page=' + ++req.query.page + '"}');
     }
     else {
       coverage["PagingFragment"]++;
-      res.status(200).end('{"values": [ {"properties":{"id" : ' + req.params.pagenumber + ', "name": "product"}} ]}');
+      res.status(200).end('{"values": [ {"properties":{"id" : ' + req.query.page + ', "name": "product"}} ]}');
     }
   });
 

--- a/src/dev/TestServer/swagger/paging.json
+++ b/src/dev/TestServer/swagger/paging.json
@@ -284,12 +284,12 @@
     },
     "/paging/multiple/fragment/{tenant}": {
       "get": {
-        "x-ms-pageable": { "nextLinkName": "odata.nextLink", "itemName": "values" },
+        "x-ms-pageable": { "nextLinkName": "odata.nextLink", "itemName": "values", "operationName": "Paging_nextFragment" },
         "operationId": "Paging_getMultiplePagesFragmentNextLink",
         "description": "A paging operation that doesn't return a full URL, just a fragment",
         "parameters": [
           {
-            "name": "api-version",
+            "name": "api_version",
             "in": "query",
             "required": true,
             "type": "string",
@@ -318,14 +318,14 @@
     }
   },
   "x-ms-paths": {
-    "/paging/multiple/fragment/{tenant}/next": {
+    "/paging/multiple/fragment/{tenant}/{nextLink}": {
       "get": {
-        "x-ms-pageable": { "nextLinkName": "odata.nextLink", "itemName": "values" },
-        "operationId": "Paging_getMultiplePagesFragmentNextLinkNext",
+        "x-ms-pageable": { "nextLinkName": "odata.nextLink", "itemName": "values", "operationName": "Paging_nextFragment" },
+        "operationId": "Paging_nextFragment",
         "description": "A paging operation that doesn't return a full URL, just a fragment",
         "parameters": [
           {
-            "name": "api-version",
+            "name": "api_version",
             "in": "query",
             "required": true,
             "type": "string",
@@ -339,11 +339,12 @@
             "description": "Sets the tenant to use."
           },
           {
-            "name": "page",
-            "in": "query",
+            "name": "nextLink",
+            "in": "path",
             "required": true,
             "type": "string",
-            "description": "Sets the page to retrieve."
+            "description": "Next link for list operation.",
+            "x-ms-skip-url-encoding": true
           }
         ],
         "responses": {


### PR DESCRIPTION
These changes are a closer representation of how fragment URLs are handled in the GraphRBAC spec, however whether we want to adopt them, or take a more generic approach is up to you :)

I haven't re-generated the C# code or run the tests for these changes yet - as I wasn't sure whether you had completed the generator changes for these tests to run successfully yet.
